### PR TITLE
Fix: Reboot on failing to connect

### DIFF
--- a/src/asynch/mod.rs
+++ b/src/asynch/mod.rs
@@ -18,3 +18,25 @@ pub type UbloxUrc = crate::command::edm::urc::EdmEvent;
 
 #[cfg(not(feature = "edm"))]
 pub type UbloxUrc = crate::command::Urc;
+
+pub struct OnDrop<F: FnOnce()> {
+    f: core::mem::MaybeUninit<F>,
+}
+
+impl<F: FnOnce()> OnDrop<F> {
+    fn new(f: F) -> Self {
+        Self {
+            f: core::mem::MaybeUninit::new(f),
+        }
+    }
+
+    fn defuse(self) {
+        core::mem::forget(self)
+    }
+}
+
+impl<F: FnOnce()> Drop for OnDrop<F> {
+    fn drop(&mut self) {
+        unsafe { self.f.as_ptr().read()() }
+    }
+}

--- a/src/asynch/network.rs
+++ b/src/asynch/network.rs
@@ -154,7 +154,7 @@ where
         // credentials have been restored from persistent memory. This although
         // the wifi station has been started. So we assume that this type is
         // also ok.
-        info!("Entered network_status_callback");
+        debug!("Entered network_status_callback");
         let NetworkStatusResponse {
             status:
                 NetworkStatus::InterfaceType(InterfaceType::WifiStation | InterfaceType::Unknown),
@@ -183,7 +183,7 @@ where
         else {
             return Err(Error::Network);
         };
-        info!(
+        debug!(
             "Network status callback ipv4: {:?}",
             core::str::from_utf8(&ipv4).ok()
         );
@@ -193,7 +193,7 @@ where
             .and_then(|s| Ipv4Addr::from_str(s).ok())
             .map(|ip| !ip.is_unspecified())
             .unwrap_or_default();
-        info!("Network status callback ipv4: {:?}", ipv4_up);
+        debug!("Network status callback ipv4: {:?}", ipv4_up);
 
         #[cfg(feature = "ipv6")]
         let ipv6_up = {
@@ -231,7 +231,7 @@ where
         else {
             return Err(Error::Network);
         };
-        info!(
+        debug!(
             "Network status callback ipv6: {:?}",
             core::str::from_utf8(&ipv6_link_local).ok()
         );
@@ -242,7 +242,7 @@ where
             .map(|ip| !ip.is_unspecified())
             .unwrap_or_default();
 
-        info!("Network status callback ipv6: {:?}", ipv6_link_local_up);
+        debug!("Network status callback ipv6: {:?}", ipv6_link_local_up);
 
         // Use `ipv4_addr` & `ipv6_addr` to determine link state
         self.ch.update_connection_with(|con| {


### PR DESCRIPTION
Sometimes when we call join sta the funciton fails on the first cmd. 
I couldn't find out how to fix that properly. My guess was its because the wifi module is actively searching for the wifi so it will not receive new settings for a wifi. 
My quickfix was to tell the module to deactivate the wifi. This will after 2 seconds send a network disabled, then the network runner will set the wifistate to inactive and will reboot the module.
